### PR TITLE
refactor: move from "alert" to "node-notifier"

### DIFF
--- a/ejemplo/package.json
+++ b/ejemplo/package.json
@@ -4,11 +4,10 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "alert": "^5.0.10",
     "express": "^4.17.1",
-    "naxlowdb": "^1.0.2"
+    "naxlowdb": "^1.0.2",
+    "node-notifier": "^10.0.1"
   },
-  "devDependencies": {},
   "scripts": {
     "start": "node index.js --ignore items.json",
     "dev": "nodemon index.js --ignore items.json",

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,7 +1,7 @@
 
 	const low = require('lowdb')
 	const FileSync = require('lowdb/adapters/FileSync')
-	const alert = require('alert');
+	const notifier = require('node-notifier');
 	const adapter = new FileSync('items.json')
 	const db = low(adapter)
 
@@ -22,20 +22,20 @@
 		if (!await getJson(json.id)) {
 			await db.get('items').push(json).write()
 		} else {
-			alert('Id ' + json.id + ' ya existe')
+			notifier.notify('Id ' + json.id + ' ya existe')
 		}
 	}
 	const putJson = async(json) => {
 		if (await getJson(json.id)) {
 			await db.get('items').find({id: json.id}).assign({title: json.title}).write()
 		} else {
-			alert('Id ' + json.id + ' no existe')
+			notifier.notify('Id ' + json.id + ' no existe')
 		}
 	}
 	const deleteJson = async(json) => {
 		if (await getJson(json.id)) {
 			await db.get('items').remove({id: json.id}).write()
-			alert('Id ' + json.id + ' borrado exitosamente')
+			notifier.notify('Id ' + json.id + ' borrado exitosamente')
 		}
 	}
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,13 +4,12 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "alert": "^5.0.10",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "lowdb": "^1.0.0",
+    "node-notifier": "^10.0.1",
     "path": "^0.12.7"
   },
-  "devDependencies": {},
   "scripts": {
     "dev": "nodemon index.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Hi @naxo25 ,

The "alert" package was deprecated long time ago.

I've made a small update that switches from using the "alert" package to "node-notifier." Could you please bump the version and push this change to npm? This way, your package won't be a dependent of the "alert" package anymore.

Cheers,
Patrick